### PR TITLE
Changes to resource manager. Resolved conflicts in gameManager

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,1 +1,2 @@
-*
+/client/
+/shared/

--- a/java/src/client/data/Bank.java
+++ b/java/src/client/data/Bank.java
@@ -1,7 +1,5 @@
 package client.data;
 
-import java.util.ArrayList;
-
 public class Bank {
 
     private int ownerID;
@@ -10,25 +8,60 @@ public class Bank {
     private int roads;
     private boolean hasLongestRoad;
     private boolean hasLargestArmy;
-    private ArrayList<Card> resourcesCards;
-    private ArrayList<Card> developmentCards;
-    private ArrayList<Card> soldiers;
-    private ArrayList<Card> monuments;
+    private ResourceList resourcesCards;
+    private DevCardList developmentCards;
+    private DevCardList unusableDevCards;
+    private int soldiers;
+    private int monuments;
+    private final int mainBankIndex = 4;
 
-    public Bank(int ownerID, boolean hasLongestRoad, boolean hasLargestArmy, ArrayList<Card> resourcesCards, ArrayList<Card> developmentCards, ArrayList<Card> soldiers, ArrayList<Card> monuments) {
+    public Bank(Player p, boolean hasLargestArmy, boolean hasLongestRoad) {
+	    this.ownerID = p.getPlayerID();
+	    this.hasLongestRoad = hasLongestRoad;
+	    this.hasLargestArmy = hasLargestArmy;
+	    this.resourcesCards = p.getResources();
+	    this.developmentCards = p.getOldDevCards();
+	    this.unusableDevCards = new DevCardList();
+	    this.soldiers = p.getSoldiers();
+	    this.monuments = p.getMonuments();
+	    this.settlements = p.getSettlements();
+	    this.cities = p.getCities();
+	    this.roads = p.getRoads();
+	}
+    
+    
+    public Bank(int ownerID, boolean hasLongestRoad, boolean hasLargestArmy, ResourceList resourcesCards, DevCardList developmentCards, DevCardList unusableDevCards,
+    			int soldiers, int monuments, int settlements, int cities, int roads) {
         this.ownerID = ownerID;
         this.hasLongestRoad = hasLongestRoad;
         this.hasLargestArmy = hasLargestArmy;
         this.resourcesCards = resourcesCards;
         this.developmentCards = developmentCards;
+        this.unusableDevCards = unusableDevCards;
         this.soldiers = soldiers;
         this.monuments = monuments;
-        settlements = 5;
-        cities = 4;
-        roads = 15;
+        this.settlements = settlements;
+        this.cities = cities;
+        this.roads = roads;
+    }
+    
+
+    public Bank(ResourceList resourceCards, DevCardList developmentCards, boolean hasLargestArmy, boolean hasLongestRoad) {
+        this.ownerID = mainBankIndex;
+        this.hasLongestRoad = hasLongestRoad;
+        this.hasLargestArmy = hasLargestArmy;
+        this.resourcesCards = resourceCards;
+        this.developmentCards = developmentCards;
+        this.unusableDevCards = new DevCardList();
+        this.soldiers = 0;
+        this.monuments = 0;
+        this.settlements = 0;
+        this.cities = 0;
+        this.roads = 0;	
     }
 
-    public int getSettlements() {
+
+	public int getSettlements() {
         return settlements;
     }
 
@@ -36,6 +69,14 @@ public class Bank {
         this.settlements = settlements;
     }
 
+    public void removeSettlement(){
+    	settlements--;
+    }
+    
+    public void addSettlement() {
+    	settlements++;
+    }
+    
     public int getCities() {
         return cities;
     }
@@ -44,6 +85,10 @@ public class Bank {
         this.cities = cities;
     }
 
+    public void removeCity(){
+    	cities--;
+    }
+    
     public int getRoads() {
         return roads;
     }
@@ -52,6 +97,10 @@ public class Bank {
         this.roads = roads;
     }
 
+    public void removeRoad(){
+    	roads--;
+    }
+    
     public int getOwnerID() {
         return ownerID;
     }
@@ -60,7 +109,7 @@ public class Bank {
         this.ownerID = ownerID;
     }
 
-    public boolean isHasLongestRoad() {
+    public boolean HasLongestRoad() {
         return hasLongestRoad;
     }
 
@@ -68,7 +117,7 @@ public class Bank {
         this.hasLongestRoad = hasLongestRoad;
     }
 
-    public boolean isHasLargestArmy() {
+    public boolean HasLargestArmy() {
         return hasLargestArmy;
     }
 
@@ -76,38 +125,82 @@ public class Bank {
         this.hasLargestArmy = hasLargestArmy;
     }
 
-    public ArrayList<Card> getResourcesCards() {
+    public ResourceList getResourcesCards() {
         return resourcesCards;
     }
 
-    public void setResourcesCards(ArrayList<Card> resourcesCards) {
+    public void setResourcesCards(ResourceList resourcesCards) {
         this.resourcesCards = resourcesCards;
     }
 
-    public ArrayList<Card> getDevelopmentCards() {
+    public DevCardList getDevelopmentCards() {
         return developmentCards;
     }
 
-    public void setDevelopmentCards(ArrayList<Card> developmentCards) {
+    public void setDevelopmentCards(DevCardList developmentCards) {
         this.developmentCards = developmentCards;
     }
 
-    public ArrayList<Card> getSoldiers() {
+    public int getSoldiers() {
         return soldiers;
     }
 
-    public void setSoldiers(ArrayList<Card> soldiers) {
+    public void setSoldiers(int soldiers) {
         this.soldiers = soldiers;
     }
+    
+    public void addSoldier() {
+    	this.soldiers++;
+    }
 
-    public ArrayList<Card> getMonuments() {
+    public int getMonuments() {
         return monuments;
     }
 
-    public void setMonuments(ArrayList<Card> monuments) {
+    public void setMonuments(int monuments) {
         this.monuments = monuments;
     }
+    
+    public void addMonument(){
+    	this.monuments++;
+    }
 
+	public DevCardList getUnusableDevCards() {
+		return unusableDevCards;
+	}
+
+	public void setUnusableDevCards(DevCardList unusableDevCards) {
+		this.unusableDevCards = unusableDevCards;
+	}
+
+	public void makeCardsUsable() {
+		int monuments = unusableDevCards.getMonument();
+		for(int i = 0; i < monuments; i++){
+			this.unusableDevCards.removeMonument();
+			this.developmentCards.addMonument();
+		}
+		int monopolies = unusableDevCards.getMonopoly();
+		for(int i = 0; i < monopolies; i++){
+			this.unusableDevCards.removeMonopoly();
+			this.developmentCards.addMonopoly();
+		}
+		int yearsOfPlenty = unusableDevCards.getYearOfPlenty();
+		for(int i = 0; i < yearsOfPlenty; i++){
+			this.unusableDevCards.removeYearOfPlenty();
+			this.developmentCards.addYearOfPlenty();
+		}
+		int roadBuildings = unusableDevCards.getRoadBuilding();
+		for(int i = 0; i < roadBuildings; i++){
+			this.unusableDevCards.removeRoadBuilding();
+			this.developmentCards.addRoadBuilding();
+		}
+		int soldiers = unusableDevCards.getSoldier();
+		for(int i = 0; i < soldiers; i++){
+			this.unusableDevCards.removeSoldier();
+			this.developmentCards.addSoldier();
+		}		
+	}
+	
     @Override
     public int hashCode() {
         int hash = 7;
@@ -134,5 +227,6 @@ public class Bank {
     public String toString() {
         return "Bank{" + "ownerID=" + ownerID + ", hasLongestRoad=" + hasLongestRoad + ", hasLargestArmy=" + hasLargestArmy + ", resourcesCards=" + resourcesCards + ", developmentCards=" + developmentCards + ", soldiers=" + soldiers + ", monuments=" + monuments + '}';
     }
+
 
 }

--- a/java/src/client/data/Card.java
+++ b/java/src/client/data/Card.java
@@ -1,62 +1,62 @@
-package client.data;
-
-import shared.definitions.ResourceType;
-import shared.definitions.DevCardType;
-
-public class Card {
-    private boolean isResource;
-    private ResourceType resourceType;
-    private DevCardType developementCardType;
-    private boolean canUse;
-    private boolean used;
-
-    public Card(boolean isResource, ResourceType resourceType, DevCardType developementCardType, boolean canUse, boolean used) {
-        this.isResource = isResource;
-        this.resourceType = resourceType;
-        this.developementCardType = developementCardType;
-        this.canUse = canUse;
-        this.used = used;
-    }
-
-    public boolean isIsResource() {
-        return isResource;
-    }
-
-    public void setIsResource(boolean isResource) {
-        this.isResource = isResource;
-    }
-
-    public ResourceType getResourceType() {
-        return resourceType;
-    }
-
-    public void setResourceType(ResourceType resourceType) {
-        this.resourceType = resourceType;
-    }
-
-    public DevCardType getDevelopementCardType() {
-        return developementCardType;
-    }
-
-    public void setDevelopementCardType(DevCardType developementCardType) {
-        this.developementCardType = developementCardType;
-    }
-
-    public boolean isCanUse() {
-        return canUse;
-    }
-
-    public void setCanUse(boolean canUse) {
-        this.canUse = canUse;
-    }
-
-    public boolean isUsed() {
-        return used;
-    }
-
-    public void setUsed(boolean used) {
-        this.used = used;
-    }
-    
-    
-}
+//package client.data;
+//
+//import shared.definitions.ResourceType;
+//import shared.definitions.DevCardType;
+//
+//public class Card {
+//    private boolean isResource;
+//    private ResourceType resourceType;
+//    private DevCardType developementCardType;
+//    private boolean canUse;
+//    private boolean used;
+//
+//    public Card(boolean isResource, ResourceType resourceType, DevCardType developementCardType, boolean canUse, boolean used) {
+//        this.isResource = isResource;
+//        this.resourceType = resourceType;
+//        this.developementCardType = developementCardType;
+//        this.canUse = canUse;
+//        this.used = used;
+//    }
+//
+//    public boolean isIsResource() {
+//        return isResource;
+//    }
+//
+//    public void setIsResource(boolean isResource) {
+//        this.isResource = isResource;
+//    }
+//
+//    public ResourceType getResourceType() {
+//        return resourceType;
+//    }
+//
+//    public void setResourceType(ResourceType resourceType) {
+//        this.resourceType = resourceType;
+//    }
+//
+//    public DevCardType getDevelopementCardType() {
+//        return developementCardType;
+//    }
+//
+//    public void setDevelopementCardType(DevCardType developementCardType) {
+//        this.developementCardType = developementCardType;
+//    }
+//
+//    public boolean isCanUse() {
+//        return canUse;
+//    }
+//
+//    public void setCanUse(boolean canUse) {
+//        this.canUse = canUse;
+//    }
+//
+//    public boolean isUsed() {
+//        return used;
+//    }
+//
+//    public void setUsed(boolean used) {
+//        this.used = used;
+//    }
+//    
+//    
+//}

--- a/java/src/client/data/DevCardList.java
+++ b/java/src/client/data/DevCardList.java
@@ -1,5 +1,10 @@
 package client.data;
 
+import java.util.List;
+import java.util.Random;
+
+import shared.definitions.DevCardType;
+
 /*
  * To change this license header, choose License Headers in Project Properties.
  * To change this template file, choose Tools | Templates
@@ -11,65 +16,153 @@ package client.data;
  * @author ddennis
  */
 public class DevCardList {
-   private int monopoly;
-   private int monument;
-   private int roadBuilding;
-   private int soldier;
-   private int yearOfPlenty;
+	private int monopoly;
+	private int monument;
+	private int roadBuilding;
+	private int soldier;
+	private int yearOfPlenty;
 
-    public DevCardList(int monopoly, int monument, int roadBuilding, int soldier, int yearOfPlenty) {
-        this.monopoly = monopoly;
-        this.monument = monument;
-        this.roadBuilding = roadBuilding;
-        this.soldier = soldier;
-        this.yearOfPlenty = yearOfPlenty;
-    }
+	public DevCardList() {
+		this.monopoly = 0;
+		this.monument = 0;
+		this.roadBuilding = 0;
+		this.soldier = 0;
+		this.yearOfPlenty = 0;
+	}
+	
+	public DevCardList(List<Player> players) {
+		this.monopoly = 2;
+		this.monument = 5;
+		this.roadBuilding = 2;
+		this.soldier = 14;
+		this.yearOfPlenty = 2;
+		
+		for(Player p : players){
+			this.monopoly -= p.getOldDevCards().getMonopoly();
+			this.monument -= p.getOldDevCards().getMonument();
+			this.monument -= p.getMonuments();
+			this.roadBuilding -= p.getOldDevCards().getRoadBuilding();
+			this.yearOfPlenty -= p.getOldDevCards().getYearOfPlenty();
+			this.soldier -= p.getOldDevCards().getSoldier();
+			this.soldier -= p.getSoldiers();
+			
+			
+		}
+	}
+	
+	public DevCardList(int monopoly, int monument, int roadBuilding, int soldier, int yearOfPlenty) {
+		this.monopoly = monopoly;
+		this.monument = monument;
+		this.roadBuilding = roadBuilding;
+		this.soldier = soldier;
+		this.yearOfPlenty = yearOfPlenty;
+	}
 
-    public int getMonopoly() {
-        return monopoly;
-    }
+	public int getMonopoly() {
+		return monopoly;
+	}
 
-    public void setMonopoly(int monopoly) {
-        this.monopoly = monopoly;
-    }
+	public void setMonopoly(int monopoly) {
+		this.monopoly = monopoly;
+	}
+	
+	public void addMonopoly() {
+		this.monopoly++;
+	}
+	
+	public void removeMonopoly() {
+		this.monopoly--;
+	}
 
-    public int getMonument() {
-        return monument;
-    }
+	public int getMonument() {
+		return monument;
+	}
 
-    public void setMonument(int monument) {
-        this.monument = monument;
-    }
+	public void setMonument(int monument) {
+		this.monument = monument;
+	}
 
-    public int getRoadBuilding() {
-        return roadBuilding;
-    }
+	public void addMonument() {
+		this.monument++;
+	}
+	
+	public void removeMonument() {
+		this.monument--;
+	}
 
-    public void setRoadBuilding(int roadBuilding) {
-        this.roadBuilding = roadBuilding;
-    }
+	public int getRoadBuilding() {
+		return roadBuilding;
+	}
 
-    public int getSoldier() {
-        return soldier;
-    }
+	public void setRoadBuilding(int roadBuilding) {
+		this.roadBuilding = roadBuilding;
+	}
 
-    public void setSoldier(int soldier) {
-        this.soldier = soldier;
-    }
+	public void addRoadBuilding() {
+		this.roadBuilding++;
+	}
+	
+	public void removeRoadBuilding() {
+		this.roadBuilding--;
+	}
 
-    public int getYearOfPlenty() {
-        return yearOfPlenty;
-    }
+	public int getSoldier() {
+		return soldier;
+	}
 
-    public void setYearOfPlenty(int yearOfPlenty) {
-        this.yearOfPlenty = yearOfPlenty;
-    }
+	public void setSoldier(int soldier) {
+		this.soldier = soldier;
+	}
 
-    @Override
-    public String toString() {
-        return "{" + "monopoly : " + monopoly + ", monument : " + monument + ", roadBuilding : " + roadBuilding + ", soldier : " + soldier + ", yearOfPlenty : " + yearOfPlenty + '}';
+	public void addSoldier() {
+		this.soldier++;
+	}
+	
+	public void removeSoldier() {
+		this.soldier--;
+	}
+
+	public int getYearOfPlenty() {
+		return yearOfPlenty;
+	}
+
+	public void setYearOfPlenty(int yearOfPlenty) {
+		this.yearOfPlenty = yearOfPlenty;
+	}
+
+	public void addYearOfPlenty() {
+		this.yearOfPlenty++;
+	}
+	
+	public void removeYearOfPlenty() {
+		this.yearOfPlenty--;
+	}
+
+	public DevCardType selectRandomDevCard() {
+    	Random r = new Random();
+    	int cardType = r.nextInt(totalCardsRemaining()) + 1;
+
+    	if(cardType <= this.monopoly){
+    		return DevCardType.MONOPOLY;
+    	} else if (cardType <= this.monopoly + this.monument) {
+    		return DevCardType.MONUMENT;
+    	} else if (cardType <= this.monopoly + this.monument + this.roadBuilding){
+    		return DevCardType.ROAD_BUILD;
+    	} else if (cardType <= this.monopoly + this.monument + this.roadBuilding + this.yearOfPlenty) {
+    		return DevCardType.YEAR_OF_PLENTY;
+    	} else {
+    		return DevCardType.SOLDIER;
+    	}
     }
-   
-   
-    
+	
+	public int totalCardsRemaining(){
+		return this.monopoly + this.monument + this.roadBuilding + this.yearOfPlenty + this.soldier;
+	}
+
+	@Override
+	public String toString() {
+		return "{" + "monopoly : " + monopoly + ", monument : " + monument + ", roadBuilding : " + roadBuilding
+				+ ", soldier : " + soldier + ", yearOfPlenty : " + yearOfPlenty + '}';
+	}
+	
 }

--- a/java/src/client/data/Game.java
+++ b/java/src/client/data/Game.java
@@ -1,6 +1,5 @@
 package client.data;
 
-import java.util.ArrayList;
 import java.util.List;
 
 public class Game {

--- a/java/src/client/data/ResourceList.java
+++ b/java/src/client/data/ResourceList.java
@@ -1,4 +1,7 @@
 package client.data;
+
+import shared.definitions.ResourceType;
+
 /*
  * To change this license header, choose License Headers in Project Properties.
  * To change this template file, choose Tools | Templates
@@ -17,6 +20,42 @@ public class ResourceList {
     private int wheat;
     private int wood;
 
+    public ResourceList() {
+    	brick = 0;
+    	ore = 0;
+    	sheep = 0;
+    	wheat = 0;
+    	wood = 0;
+    }
+    
+    public ResourceList(ResourceType type) {
+    	brick = 0;
+    	ore = 0;
+    	sheep = 0;
+    	wheat = 0;
+    	wood = 0;
+    	
+    	switch(type){
+    	case BRICK:
+    		brick++;
+    		break;
+    	case ORE:
+    		ore++;
+    		break;
+    	case SHEEP:
+    		sheep++;
+    		break;
+    	case WHEAT:
+    		wheat++;
+    		break;
+    	case WOOD:
+    		wood++;
+    		break;
+   		default:
+   			//Should never occur
+    	}
+    }
+    
     public ResourceList(int brick, int ore, int sheep, int wheat, int wood) {
         this.brick = brick;
         this.ore = ore;
@@ -32,6 +71,14 @@ public class ResourceList {
     public void setBrick(int brick) {
         this.brick = brick;
     }
+    
+    public void addBrick(int amount) {
+    	this.brick += amount;
+    }
+
+    public void removeBrick(int amount) {
+    	this.brick -= amount;
+    }
 
     public int getOre() {
         return ore;
@@ -39,6 +86,14 @@ public class ResourceList {
 
     public void setOre(int ore) {
         this.ore = ore;
+    }
+
+    public void addOre(int amount) {
+    	this.ore += amount;
+    }
+
+    public void removeOre(int amount) {
+    	this.ore -= amount;
     }
 
     public int getSheep() {
@@ -49,12 +104,28 @@ public class ResourceList {
         this.sheep = sheep;
     }
 
+    public void addSheep(int amount) {
+    	this.sheep += amount;
+    }
+
+    public void removeSheep(int amount) {
+    	this.sheep -= amount;
+    }
+
     public int getWheat() {
         return wheat;
     }
 
     public void setWheat(int wheat) {
         this.wheat = wheat;
+    }
+
+    public void addWheat(int amount) {
+    	this.wheat += amount;
+    }
+
+    public void removeWheat(int amount) {
+    	this.wheat -= amount;
     }
 
     public int getWood() {
@@ -64,6 +135,20 @@ public class ResourceList {
     public void setWood(int wood) {
         this.wood = wood;
     }
+    
+    public void addWood(int amount) {
+    	this.wood += amount;
+    }
+
+    public void removeWood(int amount) {
+    	this.wood -= amount;
+    }
+
+    public boolean hasCardsAvailable(ResourceList request) {	
+    	return request.getBrick() <= this.getBrick() && request.getOre() <= this.getOre() && request.getSheep() <= this.getSheep() 
+    			&& request.getWheat() <= this.getWheat() && request.getWheat() <= this.getWheat();
+    }
+    
     /**
      * 
      * @pre none

--- a/java/src/client/data/TradeOffer.java
+++ b/java/src/client/data/TradeOffer.java
@@ -1,7 +1,5 @@
 package client.data;
 
-import shared.definitions.ResourceType;
-
 public class TradeOffer {
 
     private int sender;

--- a/java/src/client/managers/GameManager.java
+++ b/java/src/client/managers/GameManager.java
@@ -1,6 +1,7 @@
 package client.managers;
 
-import client.data.Card;
+import client.data.Bank;
+import client.data.DevCardList;
 import client.data.Edge;
 import client.data.Game;
 import client.data.Hex;
@@ -16,6 +17,7 @@ import java.util.Random;
 import java.util.Date;
 
 import shared.definitions.DevCardType;
+import shared.definitions.PieceType;
 import shared.definitions.ResourceType;
 import shared.locations.VertexLocation;
 import shared.locations.EdgeLocation;
@@ -32,6 +34,7 @@ public class GameManager {
     private ResourceManager resourceManager;
     private Random randomness;
     private Game game;
+    private final int mainBankIndex = 4;
 
     public GameManager() {
         randomness = new Random();
@@ -60,11 +63,18 @@ public class GameManager {
         mapManager.setHexList(game.getMap().getHexes());
 
         //Resource Manager
-        List<ResourceList> gameBanks = new ArrayList<>();
-        for (Player player : game.getPlayers()) {
-            gameBanks.add(player.getPlayerIndex(), player.getResources());
+        List<Bank> gameBanks = new ArrayList<>();
+        for (int i = 0; i < game.getPlayers().size(); i++) {
+        	Player p = game.getPlayers().get(i);
+        	boolean hasLargestArmy = (p.getPlayerID() == game.getTurnTracker().getLargestArmy());
+        	boolean hasLongestRoad = (p.getPlayerID() == game.getTurnTracker().getLongestRoad());
+        	gameBanks.add(new Bank(p, hasLargestArmy, hasLongestRoad));
         }
-        gameBanks.add(4, game.getBank());
+
+        DevCardList mainBankDevCards = new DevCardList(game.getPlayers());
+    	boolean hasLargestArmy = (mainBankIndex == game.getTurnTracker().getLargestArmy());
+    	boolean hasLongestRoad = (mainBankIndex == game.getTurnTracker().getLongestRoad());
+        gameBanks.add(new Bank(game.getBank(), mainBankDevCards, hasLargestArmy, hasLongestRoad));
         resourceManager.setGameBanks(gameBanks);
 
     }
@@ -316,7 +326,7 @@ public class GameManager {
 
 //        int dieRoll = randomness.nextInt(6) + randomness.nextInt(6) + 2;
         List<Hex> hexesProducingResources = mapManager.getTerrainResourceHexes(dieRoll);
-        ResourceList gameBank = resourceManager.getGameBanks().get(4);
+        ResourceList gameBank = resourceManager.getGameBanks().get(mainBankIndex).getResourcesCards();
 
         for (ResourceType resourceType : ResourceType.values()) {
             List<Hex> hexesProducingAParticularResource = new ArrayList<>();
@@ -360,9 +370,9 @@ public class GameManager {
             }
 
             if (amountAvailable >= playersEarningResources.size()) {
-                Card transferringCard = new Card(true, resourceType, DevCardType.MONOPOLY, true, false);
+                ResourceList resource = new ResourceList(resourceType);
                 for (Integer earningPlayer : playersEarningResources) {
-                    resourceManager.transferCard(4, earningPlayer, transferringCard);
+                    resourceManager.transferResourceCard(mainBankIndex, earningPlayer, resource);
                 }
             }
 
@@ -370,14 +380,14 @@ public class GameManager {
 
     }
 
-    public void diceIsSevenMoveRober(HexLocation newLocationForRobber) {
+    public void diceIsSevenMoveRobber(HexLocation newLocationForRobber) {
         if (mapManager.moveRobber(newLocationForRobber))
         {
 
             for (int i = 0; i < 4; i++) {
-                int numberOfResourceCards = resourceManager.getGameBanks().get(i).getTotalResources();
+                int numberOfResourceCards = resourceManager.getGameBanks().get(i).getResourcesCards().getTotalResources();
                 if (numberOfResourceCards >= 7) {
-                    resourceManager.playerDiscardsHalfCards(i);
+                    resourceManager.playerDiscardsHalfCards(i, new ResourceList());
                 }
             }
         }
@@ -391,7 +401,7 @@ public class GameManager {
      * @post Success = Cards will be transferred between current player bank and
      * game bank.
      */
-    public boolean buy(int gameID, String card) {
+    public boolean buyDevCard() {
 
         return false;
     }
@@ -404,7 +414,7 @@ public class GameManager {
      * @post Success = Structure built, player victory point incremented,
      * structure count decremented.
      */
-    public boolean build(int gameID, String object) {
+    public boolean build(int gameID, PieceType type) {
 
         return false;
     }
@@ -422,7 +432,7 @@ public class GameManager {
      * @post Failure = Receiver doesn't have the requested cards; Success =
      * cards are transferred between the two player's banks.
      */
-    public boolean trade(int gameID, int senderID, int receiverID, ArrayList<Card> offer, ArrayList<Card> request) {
+    public boolean trade(int gameID, int senderID, int receiverID, ResourceList offer, ResourceList request) {
 
         return false;
     }
@@ -436,7 +446,7 @@ public class GameManager {
      * card. Then it will be moved to another part of the player's bank) Card
      * effect will be carried out.
      */
-    public boolean useCard(int gameID, Card c) {
+    public boolean useDevCard(DevCardType type) {
 
         return false;
     }


### PR DESCRIPTION
Change notes:

--ResourceManager--
gameBanks property changed from List<ResourceList> to List<Bank>
--> Note: the ResourceManager needs access to each player's entire bank. Not just their resources. Maybe we should rename it "BankManager"

transferCard() renamed --> "transferResourceCard()"
--> transferResourceCard() takes a whole ResourceList instead of a single Card.

"shuffleDevelopmentCards()" method removed
--> added "selectRandomDevCard()" method to DevCardList class. This method takes a random dev card from the bank's remaining dev cards.

"awardLargestArmy()" renamed --> "moveLargestArmy()"
"awardLongestRoad()" renamed --> "moveLongestRoad()"

added parameter "toDiscard" (ResourceList) to the "playerDiscardsHalfCards" method
--> the game should force the player to choose the necessary amount of cards to discard and pass the player-selected list to the resource manager

renamed the "use<devCard>" methods to "<devCard>Used"
--> the gameManager should be disabling the illegal operations at the gui-level. These should only be responsible for disposing of devCards + adding soldier/victPoints

--GameManager--
Resolved conflicts caused by changes to the ResourceManager

-->All calls to "transferCard" have been replaced with working(probably) calls to "transferResourceCard"
-->InitializeGame had to be modified to send Banks to the ResourceManager, instead of just ResourceLists

@!#$!@#$:
There is absolutely no possible way in their json catan-model to keep track of changes made to the main bank's remaining development cards.
I had to rig it to subtract all the players' existing devCards, soldiers, and monuments from the maximum amount available. This means that progress cards, once played, are not being properly removed from the game.
